### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "screeninfo==0.8.1",
         "wakepy==0.7.2",
         "show-in-file-manager==1.1.4"
+        "numpy==1.26.4"
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
numpy 2.0 throws error, must have Numpy < 2 
I can provide error log if needed, but this is the direct fix

```pip install numpy==1.26.4```

modified setup.py 