### PR TITLE
Fix: Missing comma in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "flaskwebgui",
         "screeninfo==0.8.1",
         "wakepy==0.7.2",
-        "show-in-file-manager==1.1.4"
+        "show-in-file-manager==1.1.4",
         "numpy==1.26.4"
     ],
     packages=find_packages(),


### PR DESCRIPTION
There is a missing comma in setup.py that prevents dependencies to be correctly installed.