### PR TITLE
fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ aTrain has a speaker detection mode based on [pyannote.audio](https://github.com
 \
 **Privacy Preservation and GDPR compliance 🔒**
 \
-aTrain processes the provided speech recordings completely offline on your own device and does not send recordings or transcriptions to the internet. This helps researchers to maintain data privacy requirements arising from ethical guidelines or to comply with legal requirements such as the GDRP.
+aTrain processes the provided speech recordings completely offline on your own device and does not send recordings or transcriptions to the internet. This helps researchers to maintain data privacy requirements arising from ethical guidelines or to comply with legal requirements such as the GDPR.
 \
 \
 **Multi-language support 🌍**


### PR DESCRIPTION
Small typo: GDRP -> GDPR in README.md.